### PR TITLE
Add in example to the readme about using an external dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ object project extends ScalaModule with ScalafixModule {
 mill-git.fix A Scalafix linter error was reported
 ```
 
+### Using External Rules
+
+You're also able to use external Scalafix rules by adding them like the below
+example:
+
+```scala
+def scalafixIvyDeps = Agg(ivy"com.github.liancheng::organize-imports:0.4.0")
+```
+
 ### Scalafix Arguments
 
 mill-scalafix takes any argument that can be passed to the [Scalafix the command line tool](https://scalacenter.github.io/scalafix/docs/users/installation.html#command-line).  


### PR DESCRIPTION
I was using an external dependency in one of my builds and it was clear exactly how to add it. I figured it'd be helpful to have a small example in the readme.