### PR TITLE
Bump semanticdb-scalac to 4.4.30

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -46,7 +46,7 @@ object `mill-scalafix`
       developers = Seq(Developer("joan38", "Joan Goyeau", "https://github.com/joan38"))
     )
 
-  val semanticdbScalac = ivy"org.scalameta:::semanticdb-scalac:4.4.27"
+  val semanticdbScalac = ivy"org.scalameta:::semanticdb-scalac:4.4.30"
 
   override def generatedSources = T {
     val dest = T.ctx.dest


### PR DESCRIPTION
- Support Scala 2.13.7

Apparently the trick to put the dependency in a `val` did not work and scalasteward doesn't see it.