### PR TITLE
Use dummy module to trigger semanticdb-scalac updates

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -33,7 +33,10 @@ object `mill-scalafix`
   )
 
   override def buildInfoPackageName = Some("com.goyeau.mill.scalafix")
-  override def buildInfoMembers     = Map("scalafixVersion" -> scalafixVersion)
+  override def buildInfoMembers = Map(
+    "scalafixVersion"  -> scalafixVersion,
+    "semanticdbScalac" -> ScalaStewardDummyModule.ivyDeps().items.next().dep.version
+  )
 
   override def publishVersion = GitVersionModule.version(withSnapshotSuffix = true)()
   def pomSettings =
@@ -45,21 +48,13 @@ object `mill-scalafix`
       versionControl = VersionControl.github("joan38", "mill-scalafix"),
       developers = Seq(Developer("joan38", "Joan Goyeau", "https://github.com/joan38"))
     )
+}
 
-  val semanticdbScalac = ivy"org.scalameta:::semanticdb-scalac:4.4.30"
-
-  override def generatedSources = T {
-    val dest = T.ctx.dest
-    os.write(
-      dest / "Versions.scala",
-      s"""package com.goyeau.mill.scalafix
-         |object Versions {
-         |  val semanticdbScalac = "${semanticdbScalac.dep.version}"
-         |}
-         |""".stripMargin
-    )
-    super.generatedSources() ++ Seq(PathRef(dest))
-  }
+/** Dummy module to trigger Scala Stewards updates of the semanticdb-scalac dependency used in the plugin via BuildInfo
+  */
+object ScalaStewardDummyModule extends ScalaModule {
+  def scalaVersion = `mill-scalafix`.scalaVersion
+  def ivyDeps      = Agg(ivy"org.scalameta:::semanticdb-scalac:4.4.30")
 }
 
 object itest extends MillIntegrationTestModule {

--- a/build.sc
+++ b/build.sc
@@ -32,10 +32,12 @@ object `mill-scalafix`
     ivy"org.scala-lang.modules::scala-java8-compat:1.0.2"
   )
 
+  val semanticdbScalac = ivy"org.scalameta:::semanticdb-scalac:4.4.30"
+
   override def buildInfoPackageName = Some("com.goyeau.mill.scalafix")
   override def buildInfoMembers = Map(
     "scalafixVersion"  -> scalafixVersion,
-    "semanticdbScalac" -> ScalaStewardDummyModule.ivyDeps().items.next().dep.version
+    "semanticdbScalac" -> semanticdbScalac.dep.version
   )
 
   override def publishVersion = GitVersionModule.version(withSnapshotSuffix = true)()
@@ -54,7 +56,7 @@ object `mill-scalafix`
   */
 object ScalaStewardDummyModule extends ScalaModule {
   def scalaVersion = `mill-scalafix`.scalaVersion
-  def ivyDeps      = Agg(ivy"org.scalameta:::semanticdb-scalac:4.4.30")
+  def ivyDeps      = Agg(`mill-scalafix`.semanticdbScalac)
 }
 
 object itest extends MillIntegrationTestModule {

--- a/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
+++ b/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 trait ScalafixModule extends ScalaModule {
   override def scalacPluginIvyDeps: Target[Loose.Agg[Dep]] = super.scalacPluginIvyDeps() ++
     (if (isScala3(scalaVersion())) Agg.empty
-     else Agg(ivy"org.scalameta:::semanticdb-scalac:${Versions.semanticdbScalac}"))
+     else Agg(ivy"org.scalameta:::semanticdb-scalac:${BuildInfo.semanticdbScalac}"))
 
   override def scalacOptions: Target[Seq[String]] = super.scalacOptions() ++
     (if (isScala3(scalaVersion())) Seq("-Xsemanticdb") else Seq.empty)


### PR DESCRIPTION
Fixes: #71
### Extra improvements: 
- Use BuildInfo instead of custom code generation