### PR TITLE
support older mill 0.10.x 0.11.y patch versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -11,7 +11,7 @@ import mill.scalalib.api.ZincWorkerUtil.scalaNativeBinaryVersion
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import scalalib._
 
-val millVersions                           = Seq("0.10.0", "0.11.0") // scala-steward:off
+val millVersions                           = Seq("0.10.6", "0.11.0") // scala-steward:off
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(millVersion)
 
 object `mill-scalafix` extends Cross[MillScalafixCross](millVersions: _*)

--- a/build.sc
+++ b/build.sc
@@ -11,7 +11,7 @@ import mill.scalalib.api.ZincWorkerUtil.scalaNativeBinaryVersion
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import scalalib._
 
-val millVersions                           = Seq("0.10.12", "0.11.1")
+val millVersions                           = Seq("0.10.0", "0.11.0") // scala-steward:off
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(millVersion)
 
 object `mill-scalafix` extends Cross[MillScalafixCross](millVersions: _*)


### PR DESCRIPTION
- [Example of millVersions in alexarchambault/mill-native-image](https://github.com/alexarchambault/mill-native-image/blob/master/build.sc#L8)
    - ["Mill does not guarantee any forward binary compatibilities"](https://github.com/alexarchambault/mill-native-image/pull/70/files#r1367870330)  
    - The [comment disables Steward bumps](https://github.com/alexarchambault/mill-native-image/commit/37575064e06c353255f157309cb76cad206da7b1)

@lefou could you sanity check this is a good suggestion? 😅 I don't fully understand, but trying to copy the pattern I'm seeing. I've been looking for possible mill issues in the 0.11.1 -> 0.11.2 bump related to the `--disable-callgraph-validation` [Mill issue](https://github.com/com-lihaoyi/mill/issues/2844#issuecomment-1772778047).
