### PR TITLE
Feed to whole classpath to scalafix and fix `ExplicitResultTypes`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -12,7 +12,7 @@ import mill.scalalib.api.ZincWorkerUtil.scalaNativeBinaryVersion
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import scalalib._
 
-val millVersions                           = Seq("0.10.14", "0.11.0")
+val millVersions                           = Seq("0.10.15", "0.11.0")
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(millVersion)
 
 object `mill-scalafix` extends Cross[MillScalafixCross](millVersions)

--- a/build.sc
+++ b/build.sc
@@ -12,7 +12,7 @@ import mill.scalalib.api.ZincWorkerUtil.scalaNativeBinaryVersion
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import scalalib._
 
-val millVersions                           = Seq("0.10.12", "0.11.1")
+val millVersions                           = Seq("0.10.14", "0.11.0")
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(millVersion)
 
 object `mill-scalafix` extends Cross[MillScalafixCross](millVersions)

--- a/itest/src/check/build.sc
+++ b/itest/src/check/build.sc
@@ -3,6 +3,6 @@ import com.goyeau.mill.scalafix.ScalafixModule
 import mill.scalalib._
 
 object project extends ScalaModule with ScalafixModule {
-  def scalaVersion  = "2.13.6"
+  def scalaVersion  = "2.13.10"
   def scalacOptions = Seq("-Ywarn-unused")
 }

--- a/itest/src/custom-rule/build.sc
+++ b/itest/src/custom-rule/build.sc
@@ -6,7 +6,7 @@ import os._
 
 object project extends ScalaModule with ScalafixModule {
   def scalaVersion    = "2.13.10"
-  def scalacOptions   = Seq("-Ywarn-unused", "-Yrangepos", "-P:semanticdb:synthetics:on")
+  def semanticDbEnablePluginScalacOptions = super.semanticDbEnablePluginScalacOptions() ++ Seq("-P:semanticdb:synthetics:on")
   def scalafixIvyDeps = Agg(ivy"org.scala-lang.modules::scala-collection-migrations:2.11.0")
 }
 

--- a/itest/src/fix/.scalafix.conf
+++ b/itest/src/fix/.scalafix.conf
@@ -3,7 +3,8 @@ rules = [
   DisableSyntax
   LeakingImplicitClassVal
   NoValInForComprehension
-  ProcedureSyntax
+  ProcedureSyntax,
+  ExplicitResultTypes
 ]
 
 DisableSyntax.noVars = true

--- a/itest/src/fix/build.sc
+++ b/itest/src/fix/build.sc
@@ -6,6 +6,7 @@ import os._
 
 object project extends ScalaModule with ScalafixModule {
   def scalaVersion  = "2.13.10"
+  def scalafixScalaBinaryVersion = mill.scalalib.api.ZincWorkerUtil.scalaBinaryVersion(scalaVersion())
   def scalacOptions = Seq("-Ywarn-unused")
 }
 
@@ -14,6 +15,7 @@ def verify() =
     val fixedScala = read(pwd / "project" / "src" / "Fix.scala")
     val expected = """object Fix {
                      |  def procedure(): Unit = {}
+                     |  def myComplexMethod: Map[Int, String] = 1.to(10).map(i => i -> i.toString).toMap
                      |}
                      |""".stripMargin
     assert(fixedScala == expected)

--- a/itest/src/fix/build.sc
+++ b/itest/src/fix/build.sc
@@ -15,7 +15,7 @@ def verify() =
     val fixedScala = read(pwd / "project" / "src" / "Fix.scala")
     val expected = """object Fix {
                      |  def procedure(): Unit = {}
-                     |  def myComplexMethod: Map[Int, String] = 1.to(10).map(i => i -> i.toString).toMap
+                     |  def myComplexMethod: Map[Int,String] = 1.to(10).map(i => i -> i.toString).toMap
                      |}
                      |""".stripMargin
     assert(fixedScala == expected)

--- a/itest/src/fix/project/src/Fix.scala
+++ b/itest/src/fix/project/src/Fix.scala
@@ -1,3 +1,4 @@
 object Fix {
   def procedure() {}
+  def myComplexMethod = 1.to(10).map(i => i -> i.toString).toMap
 }

--- a/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
+++ b/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
@@ -25,7 +25,7 @@ trait ScalafixModule extends ScalaModule {
         T.ctx().log,
         repositoriesTask(),
         filesToFix(sources()).map(_.path),
-        Seq(semanticDbData().path),
+        classpath = (compileClasspath() ++ localClasspath() ++ Seq(semanticDbData())).iterator.toSeq.map(_.path),
         scalaVersion(),
         scalafixScalaBinaryVersion(),
         scalacOptions(),


### PR DESCRIPTION
Feed the whole classpath to scalafix, which is needed for some scalafix rules like `ExplicitReusltTypes` to work correctly.

Added the `ExplicitResultTypes` rule to the integration test to reproduces the initial issue discovered in a Mill PR (github.com/com-lihaoyi/mill/pull/2922) and make sure we correctly handle it.

Fix https://github.com/joan38/mill-scalafix/issues/174

This PR also raises the minimal supported Mill version to 0.10.15, as this is the fist release which makes the `ScalaModule.semanticDbEnablePluginScalacOptions` task accessible for inheriting modules.