### PR TITLE
Pass `scalaVersion` to Scalafix as needed for Scalafix `0.13.0`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -58,6 +58,14 @@ trait ITestCross extends MillIntegrationTestModule with Cross.Module[String] {
       TestInvocation.Targets(Seq("__.fix")),
       TestInvocation.Targets(Seq("verify"))
     ),
+    PathRef(sources().head.path / "fix-2.12") -> Seq(
+      TestInvocation.Targets(Seq("__.fix")),
+      TestInvocation.Targets(Seq("verify"))
+    ),
+    PathRef(sources().head.path / "fix-3.5") -> Seq(
+      TestInvocation.Targets(Seq("__.fix")),
+      TestInvocation.Targets(Seq("verify"))
+    ),
     PathRef(sources().head.path / "check") -> Seq(
       TestInvocation.Targets(Seq("__.fix", "--check"))
     ),

--- a/itest/src/custom-rule/build.sc
+++ b/itest/src/custom-rule/build.sc
@@ -5,7 +5,7 @@ import mill.scalalib._
 import os._
 
 object project extends ScalaModule with ScalafixModule {
-  def scalaVersion    = "2.12.19"
+  def scalaVersion    = "2.12.17"
   def semanticDbEnablePluginScalacOptions = super.semanticDbEnablePluginScalacOptions() ++ Seq("-P:semanticdb:synthetics:on")
   def scalafixIvyDeps = Agg(ivy"org.scala-lang.modules::scala-collection-migrations:2.12.0")
 }

--- a/itest/src/custom-rule/build.sc
+++ b/itest/src/custom-rule/build.sc
@@ -5,9 +5,9 @@ import mill.scalalib._
 import os._
 
 object project extends ScalaModule with ScalafixModule {
-  def scalaVersion    = "2.13.12"
+  def scalaVersion    = "2.12.19"
   def semanticDbEnablePluginScalacOptions = super.semanticDbEnablePluginScalacOptions() ++ Seq("-P:semanticdb:synthetics:on")
-  def scalafixIvyDeps = Agg(ivy"org.scala-lang.modules::scala-collection-migrations:2.11.0")
+  def scalafixIvyDeps = Agg(ivy"org.scala-lang.modules::scala-collection-migrations:2.12.0")
 }
 
 def verify() =

--- a/itest/src/fix-2.12/build.sc
+++ b/itest/src/fix-2.12/build.sc
@@ -5,7 +5,7 @@ import mill.scalalib._
 import os._
 
 object project extends ScalaModule with ScalafixModule {
-  def scalaVersion  = "2.12.19"
+  def scalaVersion  = "2.12.17"
   def scalacOptions = Seq("-Ywarn-unused")
   def ivyDeps = Agg(ivy"org.scala-lang.modules::scala-collection-compat:2.12.0")
 }

--- a/itest/src/fix-2.12/build.sc
+++ b/itest/src/fix-2.12/build.sc
@@ -5,14 +5,17 @@ import mill.scalalib._
 import os._
 
 object project extends ScalaModule with ScalafixModule {
-  def scalaVersion  = "2.12.17"
+  def scalaVersion  = "2.12.19"
   def scalacOptions = Seq("-Ywarn-unused")
+  def ivyDeps = Agg(ivy"org.scala-lang.modules::scala-collection-compat:2.12.0")
 }
 
 def verify() =
   T.command {
     val fixedScala = read(pwd / "project" / "src" / "Fix.scala")
-    val expected = """object Fix {
+    val expected = """
+                     |
+                     |object Fix {
                      |  def procedure(): Unit = {}
                      |}
                      |""".stripMargin

--- a/itest/src/fix-3.5/.scalafix.conf
+++ b/itest/src/fix-3.5/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  ExplicitResultTypes
+]

--- a/itest/src/fix-3.5/build.sc
+++ b/itest/src/fix-3.5/build.sc
@@ -12,8 +12,11 @@ def verify() =
   T.command {
     val fixedScala = read(pwd / "project" / "src" / "Fix.scala")
     val expected = """object Fix {
-                     |  def myComplexMethod: Map[Int, String] = 1.to(10).map(i => i -> i.toString).toMap
+                     |  // use a 3.5.x-only feature to fail if a Scala 3 LTS compiler is used 
+                     |  // https://www.scala-lang.org/blog/2024/08/22/scala-3.5.0-released.html#support-for-binary-integer-literals 
+                     |  def myComplexMethod: Map[Int, String] = 1.to(0B1010).map(i => i -> i.toString).toMap
                      |}
                      |""".stripMargin
+    println(fixedScala)
     assert(fixedScala == expected)
   }

--- a/itest/src/fix-3.5/build.sc
+++ b/itest/src/fix-3.5/build.sc
@@ -15,6 +15,5 @@ def verify() =
                      |  def myComplexMethod: Map[Int, String] = 1.to(10).map(i => i -> i.toString).toMap
                      |}
                      |""".stripMargin
-    println(fixedScala)
     assert(fixedScala == expected)
   }

--- a/itest/src/fix-3.5/build.sc
+++ b/itest/src/fix-3.5/build.sc
@@ -1,0 +1,20 @@
+import $file.plugins
+import com.goyeau.mill.scalafix.ScalafixModule
+import mill._
+import mill.scalalib._
+import os._
+
+object project extends ScalaModule with ScalafixModule {
+  def scalaVersion = "3.5.1"
+}
+
+def verify() =
+  T.command {
+    val fixedScala = read(pwd / "project" / "src" / "Fix.scala")
+    val expected = """object Fix {
+                     |  def myComplexMethod: Map[Int, String] = 1.to(10).map(i => i -> i.toString).toMap
+                     |}
+                     |""".stripMargin
+    println(fixedScala)
+    assert(fixedScala == expected)
+  }

--- a/itest/src/fix-3.5/build.sc
+++ b/itest/src/fix-3.5/build.sc
@@ -17,6 +17,5 @@ def verify() =
                      |  def myComplexMethod: Map[Int, String] = 1.to(0B1010).map(i => i -> i.toString).toMap
                      |}
                      |""".stripMargin
-    println(fixedScala)
     assert(fixedScala == expected)
   }

--- a/itest/src/fix-3.5/project/src/Fix.scala
+++ b/itest/src/fix-3.5/project/src/Fix.scala
@@ -1,3 +1,5 @@
 object Fix {
-  def myComplexMethod = 1.to(10).map(i => i -> i.toString).toMap
+  // use a 3.5.x-only feature to fail if a Scala 3 LTS compiler is used 
+  // https://www.scala-lang.org/blog/2024/08/22/scala-3.5.0-released.html#support-for-binary-integer-literals 
+  def myComplexMethod = 1.to(0B1010).map(i => i -> i.toString).toMap
 }

--- a/itest/src/fix-3.5/project/src/Fix.scala
+++ b/itest/src/fix-3.5/project/src/Fix.scala
@@ -1,0 +1,3 @@
+object Fix {
+  def myComplexMethod = 1.to(10).map(i => i -> i.toString).toMap
+}

--- a/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
+++ b/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
@@ -10,7 +10,6 @@ import mill.define.Command
 import scalafix.interfaces.Scalafix
 import scalafix.interfaces.ScalafixError.*
 
-import scala.annotation.nowarn
 import scala.compat.java8.OptionConverters.*
 import scala.jdk.CollectionConverters.*
 
@@ -30,7 +29,6 @@ trait ScalafixModule extends ScalaModule {
         filesToFix(sources()).map(_.path),
         classpath = (compileClasspath() ++ localClasspath() ++ Seq(semanticDbData())).iterator.toSeq.map(_.path),
         scalaVersion(),
-        scalafixScalaBinaryVersion(): @nowarn("cat=deprecation"),
         scalacOptions(),
         scalafixIvyDeps(),
         scalafixConfig(),
@@ -41,6 +39,7 @@ trait ScalafixModule extends ScalaModule {
 }
 
 object ScalafixModule {
+  @deprecated("Use overload without scalaBinaryVersion and with wd instead", since = "0.4.2")
   def fixAction(
       log: Logger,
       repositories: Seq[Repository],
@@ -58,7 +57,6 @@ object ScalafixModule {
     sources,
     classpath,
     scalaVersion,
-    scalaBinaryVersion,
     scalacOptions,
     scalafixIvyDeps,
     scalafixConfig,
@@ -66,14 +64,12 @@ object ScalafixModule {
     os.pwd
   )
 
-  @nowarn("msg=parameter scalaBinaryVersion in method fixAction is never used")
   def fixAction(
       log: Logger,
       repositories: Seq[Repository],
       sources: Seq[os.Path],
       classpath: Seq[os.Path],
       scalaVersion: String,
-      scalaBinaryVersion: String,
       scalacOptions: Seq[String],
       scalafixIvyDeps: Agg[Dep],
       scalafixConfig: Option[os.Path],
@@ -128,4 +124,30 @@ object ScalafixModule {
         if (os.isDir(pathRef.path)) os.walk(pathRef.path).filter(file => os.isFile(file) && (file.ext == "scala"))
         else Seq(pathRef.path)
     } yield PathRef(file)
+
+  @deprecated("Use overload without scalaBinaryVersion instead", since = "0.4.2")
+  def fixAction(
+      log: Logger,
+      repositories: Seq[Repository],
+      sources: Seq[os.Path],
+      classpath: Seq[os.Path],
+      scalaVersion: String,
+      scalaBinaryVersion: String,
+      scalacOptions: Seq[String],
+      scalafixIvyDeps: Agg[Dep],
+      scalafixConfig: Option[os.Path],
+      args: Seq[String],
+      wd: os.Path
+  ): Result[Unit] = fixAction(
+    log,
+    repositories,
+    sources,
+    classpath,
+    scalaVersion,
+    scalacOptions,
+    scalafixIvyDeps,
+    scalafixConfig,
+    args,
+    wd
+  )
 }


### PR DESCRIPTION
- Run all integration tests
- deprecate `scalafixScalaBinaryVersion` in favor of `scalaVersion`
- deprecate `fixAction` overloads which take scalaBinaryVersion as a parameter

Pull Request: https://github.com/joan38/mill-scalafix/pull/205