### PR TITLE
Support local rule classpath via scalafixToolClasspath

### DIFF
--- a/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixCache.scala
+++ b/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixCache.scala
@@ -17,18 +17,24 @@ private[scalafix] object ScalafixCache:
   })
 
   private val scalafixArgumentsCache =
-    new Cache[(String, Seq[Repository], Seq[Dep]), ScalafixArguments](createFunction = {
-      case (scalaVersion, repositories, scalafixIvyDeps) =>
-        val repos = repositories.map(CoursierUtils.toApiRepository).asJava
-        val deps  = scalafixIvyDeps.map(CoursierUtils.toCoordinates).iterator.toSeq.asJava
+    new Cache[(String, Seq[Repository], Seq[Dep], Seq[os.Path]), ScalafixArguments](createFunction = {
+      case (scalaVersion, repositories, scalafixIvyDeps, scalafixToolClasspath) =>
+        val repos    = repositories.map(CoursierUtils.toApiRepository).asJava
+        val deps     = scalafixIvyDeps.map(CoursierUtils.toCoordinates).iterator.toSeq.asJava
+        val toolUrls = scalafixToolClasspath.map(_.toNIO.toAbsolutePath.toUri.toURL).asJava
         scalafixCache
           .getOrElseCreate((scalaVersion, repos))
           .newArguments()
-          .withToolClasspath(Seq.empty.asJava, deps, repos)
+          .withToolClasspath(toolUrls, deps, repos)
     })
 
-  def getOrElseCreate(scalaVersion: String, repositories: Seq[Repository], scalafixIvyDeps: Seq[Dep]) =
-    scalafixArgumentsCache.getOrElseCreate((scalaVersion, repositories, scalafixIvyDeps))
+  def getOrElseCreate(
+      scalaVersion: String,
+      repositories: Seq[Repository],
+      scalafixIvyDeps: Seq[Dep],
+      scalafixToolClasspath: Seq[os.Path]
+  ) =
+    scalafixArgumentsCache.getOrElseCreate((scalaVersion, repositories, scalafixIvyDeps, scalafixToolClasspath))
 
   private class Cache[A, B <: AnyRef](createFunction: A => B):
     private val cache = new ConcurrentHashMap[A, SoftReference[B]]

--- a/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
+++ b/mill-scalafix/src/com/goyeau/mill/scalafix/ScalafixModule.scala
@@ -21,6 +21,19 @@ trait ScalafixModule extends ScalaModule:
   def scalafixConfig: T[Option[os.Path]] = Task(None)
   def scalafixIvyDeps: T[Seq[Dep]]       = Seq.empty[Dep]
 
+  /** Extra entries appended to Scalafix's tool classpath (the classloader that rules are loaded from), in addition to
+    * the published artifacts in [[scalafixIvyDeps]].
+    *
+    * Use this to load rules compiled in the same build — e.g. an in-repo rule module — without a `publishLocal` round
+    * trip:
+    * {{{
+    * def scalafixToolClasspath = Task { Seq(rules.jar()) ++ rules.runClasspath() }
+    * }}}
+    * Rule modules must target Scala 2.13, since Scalafix loads rules through a 2.13 classloader regardless of the
+    * linted module's Scala version, and typically depend on `ch.epfl.scala::scalafix-core`.
+    */
+  def scalafixToolClasspath: T[Seq[PathRef]] = Task(Seq.empty[PathRef])
+
   /** Override this to filter out repositories that don't need to be passed to scalafix
     *
     * Repositories passed to scalafix need to be converted to the coursier-interface API (coursierapi.*). This can be an
@@ -55,7 +68,8 @@ trait ScalafixModule extends ScalaModule:
         scalafixIvyDeps(),
         scalafixConfig(),
         args,
-        BuildCtx.workspaceRoot
+        BuildCtx.workspaceRoot,
+        scalafixToolClasspath().map(_.path)
       )
     }
 
@@ -95,11 +109,12 @@ object ScalafixModule:
       scalafixIvyDeps: Seq[Dep],
       scalafixConfig: Option[os.Path],
       args: Seq[String],
-      wd: os.Path
+      wd: os.Path,
+      scalafixToolClasspath: Seq[os.Path] = Seq.empty
   ): Result[Unit] =
     if sources.nonEmpty then
       val scalafix = ScalafixCache
-        .getOrElseCreate(scalaVersion, repositories, scalafixIvyDeps)
+        .getOrElseCreate(scalaVersion, repositories, scalafixIvyDeps, scalafixToolClasspath)
         .withParsedArguments(args.asJava)
         // `.toNIO.toAbsolutePath`, not bare `.toNIO`: scalafix does real filesystem work with these
         // paths and requires an absolute working directory (`require(path.isAbsolute, ...)`). Under

--- a/mill-scalafix/test/resources/local-rule/.scalafix.conf
+++ b/mill-scalafix/test/resources/local-rule/.scalafix.conf
@@ -1,0 +1,1 @@
+rules = [LocalRule]

--- a/mill-scalafix/test/resources/local-rule/build.mill
+++ b/mill-scalafix/test/resources/local-rule/build.mill
@@ -1,0 +1,16 @@
+//| repositories: [https://central.sonatype.com/repository/maven-snapshots]
+//| mvnDeps:
+//| - com.goyeau::mill-scalafix::0.6.0
+import com.goyeau.mill.scalafix.ScalafixModule
+import mill.*
+import mill.scalalib.*
+
+// In-repo Scalafix rule. Scala 2.13 because Scalafix loads rules via a 2.13 classloader.
+object rule extends ScalaModule:
+  def scalaVersion = "2.13.16"
+  def mvnDeps      = Seq(mvn"ch.epfl.scala::scalafix-core:0.14.7")
+
+// Linted module: loads the in-repo rule through `scalafixToolClasspath` (no publishLocal round trip).
+object project extends ScalaModule with ScalafixModule:
+  def scalaVersion          = "3.3.4"
+  def scalafixToolClasspath = Task { Seq(rule.jar()) ++ rule.runClasspath() }

--- a/mill-scalafix/test/resources/local-rule/project/src/Fix.scala
+++ b/mill-scalafix/test/resources/local-rule/project/src/Fix.scala
@@ -1,0 +1,2 @@
+object Fix:
+  def todo: Unit = ???

--- a/mill-scalafix/test/resources/local-rule/rule/resources/META-INF/services/scalafix.v1.Rule
+++ b/mill-scalafix/test/resources/local-rule/rule/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+fix.LocalRule

--- a/mill-scalafix/test/resources/local-rule/rule/src/fix/LocalRule.scala
+++ b/mill-scalafix/test/resources/local-rule/rule/src/fix/LocalRule.scala
@@ -1,0 +1,10 @@
+package fix
+
+import scala.meta._
+import scalafix.v1._
+
+/** Syntactic rule that rewrites `???` to `()`, used to prove a locally-built rule is loaded via scalafixToolClasspath. */
+class LocalRule extends SyntacticRule("LocalRule") {
+  override def fix(implicit doc: SyntacticDocument): Patch =
+    doc.tree.collect { case t @ Term.Name("???") => Patch.replaceTree(t, "()") }.asPatch
+}

--- a/mill-scalafix/test/src/com/goyeau/mill/scalafix/FixIntegrationTests.scala
+++ b/mill-scalafix/test/src/com/goyeau/mill/scalafix/FixIntegrationTests.scala
@@ -77,3 +77,19 @@ class FixIntegrationTests extends FunSuite:
                        |""".stripMargin
     assertEquals(fixedScala, expected)
   }
+
+  // Like the other integration tests, the `local-rule` resource resolves the *published* `com.goyeau::mill-scalafix`
+  // (pinned in its build.mill header), so this test can only pass once a release containing `scalafixToolClasspath` is
+  // out — bump that header alongside the others and drop `.ignore` at release time. Verified locally against this
+  // working copy with `./mill mill-scalafix.publishLocal` and the resource pinned to the resulting -SNAPSHOT.
+  test("fix should run rules from scalafixToolClasspath (in-repo rule modules)".ignore) {
+    val tester = Tester.create(os.rel / "local-rule")
+    val result = tester.eval(Seq("project.fix"))
+    assert(result.isSuccess, result.err)
+
+    val fixedScala = os.read(tester.workspacePath / "project" / "src" / "Fix.scala")
+    val expected   = """object Fix:
+                       |  def todo: Unit = ()
+                       |""".stripMargin
+    assertEquals(fixedScala, expected)
+  }


### PR DESCRIPTION
## Motivation

Today rules can only be added through `scalafixIvyDeps` (published artifacts). There's no supported way to load a rule **compiled in the same build** — e.g. an in-repo rule module you're iterating on — short of a `publishLocal` round trip. `ScalafixCache` hardcodes `withToolClasspath(Seq.empty.asJava, deps, repos)`, so even though `scalafix-interfaces` accepts custom classpath URLs, there's no hook to forward them.

## Change

Add `ScalafixModule.scalafixToolClasspath: T[Seq[PathRef]]` (defaults to empty). Its entries are appended to Scalafix's tool classpath alongside `scalafixIvyDeps`:

```scala
object rules extends ScalaModule:
  def scalaVersion = "2.13.16"
  def mvnDeps      = Seq(mvn"ch.epfl.scala::scalafix-core:0.14.7")

object app extends ScalaModule with ScalafixModule:
  def scalafixToolClasspath = Task { Seq(rules.jar()) ++ rules.runClasspath() }
```

The classpath is threaded through `fixAction` into the `ScalafixCache` key, and the cached `ScalafixArguments` now passes the resolved tool URLs to `withToolClasspath(...)`.

Two things kept intentionally intact:
- **Caching is preserved.** The tool classpath is part of the cache key, so the scalafix-cli/rule classloader is still built once per `(scalaVersion, repositories, ivyDeps, toolClasspath)` and reused. (Building a fresh classloader per module is what exhausts the compressed class space — `OutOfMemoryError: Compressed class space` — on large multi-module builds, so it matters that this stays cached.)
- **Backward compatible.** `scalafixToolClasspath` is a trailing parameter on `fixAction` defaulting to `Seq.empty`; existing callers and the deprecated overloads are untouched.

## Test

Adds a `local-rule` integration test: an in-repo Scala 2.13 rule module (`fix.LocalRule`, rewrites `???` → `()`) loaded via `scalafixToolClasspath` to lint a Scala 3 module.

Like the existing integration tests, the resource resolves the **published** `com.goyeau::mill-scalafix` (pinned in its `build.mill` header), so this test can only pass once a release carries the feature — it's `.ignore`d for now, with a comment to bump the header and drop `.ignore` at release time. I verified it locally against this branch:

```
./mill mill-scalafix.publishLocal          # -> 0.6.1-4-0b760cd-SNAPSHOT
# resource header pinned to that -SNAPSHOT
./mill mill-scalafix.test.testOnly com.goyeau.mill.scalafix.FixIntegrationTests -- '*scalafixToolClasspath*'
# => 0 failed, 1 total
```

`./mill mill-scalafix.checkStyle` is clean.

## Context

This generalizes a pattern I'd implemented as a downstream wrapper that reimplemented `fixAction` solely to forward local tool URLs — which, by bypassing `ScalafixCache`, reintroduced the per-module-classloader OOM. Folding the capability into the cached path here removes the need for that wrapper entirely.